### PR TITLE
refactor: remove static_context as a convenient method

### DIFF
--- a/fastimer/Cargo.toml
+++ b/fastimer/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "fastimer"
-version = "0.4.1"
+version = "0.5.0"
 
 description = "This crate implements runtime-agnostic driver for async timers and scheduled tasks."
 
@@ -48,8 +48,8 @@ tokio = { version = "1.42.0", optional = true }
 
 [dev-dependencies]
 log = { version = "0.4.22", features = ["kv"] }
-logforth = { version = "0.19.0" }
-mea = { version = "0.1.2" }
+logforth = { version = "0.21.0" }
+mea = { version = "0.2.0" }
 tokio = { version = "1.42.0", features = ["full"] }
 
 [lints]
@@ -78,6 +78,12 @@ doc-scrape-examples = true
 name = "schedule_with_fixed_delay"
 path = "examples/schedule_with_fixed_delay.rs"
 required-features = ["tokio", "logging"]
+
+[[example]]
+doc-scrape-examples = true
+name = "static_time_driver"
+path = "examples/static_time_driver.rs"
+required-features = ["driver"]
 
 [[example]]
 doc-scrape-examples = true

--- a/fastimer/examples/static_time_driver.rs
+++ b/fastimer/examples/static_time_driver.rs
@@ -1,0 +1,59 @@
+// Copyright 2024 FastLabs Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::LazyLock;
+use std::time::Duration;
+use std::time::Instant;
+
+use fastimer::driver::TimeContext;
+use fastimer::make_instant_from_now;
+
+fn static_context() -> &'static TimeContext {
+    static CONTEXT: LazyLock<TimeContext> = LazyLock::new(|| {
+        let (mut driver, context, _) = fastimer::driver::driver();
+        std::thread::Builder::new()
+            .name("fastimer-global".to_string())
+            .spawn(move || loop {
+                if driver.turn() {
+                    break;
+                }
+            })
+            .expect("cannot spawn fastimer-global thread");
+        context
+    });
+
+    &CONTEXT
+}
+
+fn assert_duration_eq(actual: Duration, expected: Duration) {
+    if expected.abs_diff(expected) > Duration::from_millis(5) {
+        panic!("expected: {:?}, actual: {:?}", expected, actual);
+    }
+}
+
+fn main() {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    rt.block_on(async move {
+        let now = Instant::now();
+
+        static_context().delay(Duration::from_secs(2)).await;
+        assert_duration_eq(now.elapsed(), Duration::from_secs(2));
+
+        let future = make_instant_from_now(Duration::from_secs(3));
+        let f1 = static_context().delay_until(future);
+        let f2 = static_context().delay_until(future);
+        tokio::join!(f1, f2);
+        assert_duration_eq(now.elapsed(), Duration::from_secs(3));
+    });
+}


### PR DESCRIPTION
It can be easily added outside. Provide an out-of-the-box method can mislead users to use a global context, which often cause subtle errors.